### PR TITLE
chore: bump version to 1.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api-proxy (1.0.6) unstable; urgency=medium
+
+  * fix: add proxy for com.deepin.lastore.Job
+
+ -- dengbo <dengbo@uniontech.com>  Sat, 6 May 2023 11:36:20 +0800
+
 dde-api-proxy (1.0.5) unstable; urgency=medium
 
   * fix: Log is too much


### PR DESCRIPTION
* release dde-api-proxy 1.0.6

Log: