### PR TITLE
fix: qdbusxml2cpp-fix not generate cpp code after dtkcore update

### DIFF
--- a/src/dbus-proxy/CMakeLists.txt
+++ b/src/dbus-proxy/CMakeLists.txt
@@ -12,9 +12,10 @@ find_package(QT NAMES Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core DBus REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(DtkCore REQUIRED)
+find_package(DtkTools REQUIRED)
 
 macro(qt5_add_dbus_proxy_interface_fix srcs xml class file)
-  execute_process(COMMAND qdbusxml2cpp-fix -c ${class} -p ${PROJECT_BINARY_DIR}/dbus-proxy/dbusinterface/${file} ${DBUS_FILE_PATH}/${xml})
+  execute_process(COMMAND ${DTK_XML2CPP} -c ${class} -p ${PROJECT_BINARY_DIR}/dbus-proxy/dbusinterface/${file} ${DBUS_FILE_PATH}/${xml})
   list(APPEND ${srcs}
     ${PROJECT_BINARY_DIR}/dbus-proxy/dbusinterface/${file}.h
     ${PROJECT_BINARY_DIR}/dbus-proxy/dbusinterface/${file}.cpp


### PR DESCRIPTION
use DtkTools and DTK_XML2CPP var instead of qdbusxml2cpp-fix binary direct

log: