### PR TITLE
fix: use Qt::endl

### DIFF
--- a/file/dbus/types/linkinfolist.cpp
+++ b/file/dbus/types/linkinfolist.cpp
@@ -42,12 +42,12 @@ const QDBusArgument &operator>>(const QDBusArgument &arg, LinkInfo &info)
 
 QDebug operator<<(QDebug arg, const LinkInfo &info)
 {
-    arg << "name = " << info.m_name << endl;
-    arg << "friendlyName = " << info.m_friendlyName << endl;
-    arg << "macAddr = " << info.m_macAddr << endl;
-    arg << "managed = " << info.m_managed << endl;
-    arg << "scanning = " << info.m_p2pScanning << endl;
-    arg << "path = " << info.m_dbusPath.path() << endl;
+    arg << "name = " << info.m_name << Qt::endl;
+    arg << "friendlyName = " << info.m_friendlyName << Qt::endl;
+    arg << "macAddr = " << info.m_macAddr << Qt::endl;
+    arg << "managed = " << info.m_managed << Qt::endl;
+    arg << "scanning = " << info.m_p2pScanning << Qt::endl;
+    arg << "path = " << info.m_dbusPath.path() << Qt::endl;
 
     return arg;
 }

--- a/file/dbus/types/sinkinfolist.cpp
+++ b/file/dbus/types/sinkinfolist.cpp
@@ -42,12 +42,12 @@ const QDBusArgument &operator>>(const QDBusArgument &arg, SinkInfo &info)
 
 QDebug operator<<(QDebug arg, const SinkInfo &info)
 {
-    arg << "name = " << info.m_name << endl;
-    arg << "p2pMac = " << info.m_p2pMac << endl;
-    arg << "interface = " << info.m_interface << endl;
-    arg << "connected = " << info.m_connected << endl;
-    arg << "peerPath = " << info.m_sinkPath.path() << endl;
-    arg << "linkPath = " << info.m_linkPath.path() << endl;
+    arg << "name = " << info.m_name << Qt::endl;
+    arg << "p2pMac = " << info.m_p2pMac << Qt::endl;
+    arg << "interface = " << info.m_interface << Qt::endl;
+    arg << "connected = " << info.m_connected << Qt::endl;
+    arg << "peerPath = " << info.m_sinkPath.path() << Qt::endl;
+    arg << "linkPath = " << info.m_linkPath.path() << Qt::endl;
 
     return arg;
 }

--- a/file/dbus/types/zoneinfo.cpp
+++ b/file/dbus/types/zoneinfo.cpp
@@ -20,7 +20,7 @@ bool ZoneInfo::operator ==(const ZoneInfo &what) const
 QDebug operator<<(QDebug argument, const ZoneInfo & info)
 {
     argument << info.m_zoneName << ',' << info.m_zoneCity << ',' << info.m_utcOffset << ',';
-    argument << info.i2 << ',' << info.i3 << ',' << info.i4 << endl;
+    argument << info.i2 << ',' << info.i3 << ',' << info.i4 << Qt::endl;
 
     return argument;
 }


### PR DESCRIPTION
Fixes warnings about deprecated bare endl.

```
warning: ‘QTextStream& QTextStreamFunctions::endl(QTextStream&)’ is deprecated: Use Qt::endl [-Wdeprecated-declarations]
```