### PR TITLE
chore: 支持1070蓝牙插件迁移的接口调用

### DIFF
--- a/src/dbus-proxy/v1/session/org_deepin_dde_Bluetooth1.hpp
+++ b/src/dbus-proxy/v1/session/org_deepin_dde_Bluetooth1.hpp
@@ -14,7 +14,13 @@ public:
         : DBusProxyBase(dbusName, dbusPath, dbusInterface, proxyDbusName, proxyDbusPath, proxyDbusInterface, dbusType, parent)
     {
         InitFilterProperies(QStringList({"CanSendFile", "State"}));
-        InitFilterMethods(QStringList({"GetAdapters", "SetAdapterPowered", "GetDevices"}));
+        InitFilterMethods(QStringList({"GetAdapters",
+                                       "SetAdapterPowered",
+                                       "GetDevices",
+                                       "RequestDiscovery",
+                                       "ConnectDevice",
+                                       "DisconnectDevice",
+                                       "ClearUnpairedDevice"}));
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()


### PR DESCRIPTION
任务栏蓝牙插件迁移，需要放开一些接口权限