### PR TITLE
chore: 将api-proxy启动提前

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -10,3 +10,7 @@ install(FILES ${INSTALL_DBUS_SYSTEMSERVICES} DESTINATION share/dbus-1/system-ser
 
 file(GLOB_RECURSE INSTALL_SYSTEMD_SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/systemd/system/*.service)
 install(FILES ${INSTALL_SYSTEMD_SYSTEM} DESTINATION lib/systemd/system/)
+
+file(GLOB_RECURSE INSTALL_SYSTEMD_USER ${CMAKE_CURRENT_SOURCE_DIR}/systemd/user/*.service)
+install(FILES ${INSTALL_SYSTEMD_USER} DESTINATION lib/systemd/user/)
+install_symlink(dde-api-dbus-proxy-v1.service dde-session-initialized.target.wants)

--- a/misc/dbus/services/com.deepin.SessionManager.service
+++ b/misc/dbus/services/com.deepin.SessionManager.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.SessionManager
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.WMSwitcher.service
+++ b/misc/dbus/services/com.deepin.WMSwitcher.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.WMSwitcher
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.api.XEventMonitor.service
+++ b/misc/dbus/services/com.deepin.api.XEventMonitor.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.api.XEventMonitor
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Appearance.service
+++ b/misc/dbus/services/com.deepin.daemon.Appearance.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Appearance
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Audio.service
+++ b/misc/dbus/services/com.deepin.daemon.Audio.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Audio
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Bluetooth.service
+++ b/misc/dbus/services/com.deepin.daemon.Bluetooth.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Bluetooth
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Display.service
+++ b/misc/dbus/services/com.deepin.daemon.Display.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Display
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.InputDevices.service
+++ b/misc/dbus/services/com.deepin.daemon.InputDevices.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.InputDevices
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Keybinding.service
+++ b/misc/dbus/services/com.deepin.daemon.Keybinding.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Keybinding
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.LangSelector.service
+++ b/misc/dbus/services/com.deepin.daemon.LangSelector.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.LangSelector
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Mime.service
+++ b/misc/dbus/services/com.deepin.daemon.Mime.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Mime
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Network.service
+++ b/misc/dbus/services/com.deepin.daemon.Network.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Network
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Power.service
+++ b/misc/dbus/services/com.deepin.daemon.Power.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Power
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.SoundEffect.service
+++ b/misc/dbus/services/com.deepin.daemon.SoundEffect.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SoundEffect
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.SystemInfo.service
+++ b/misc/dbus/services/com.deepin.daemon.SystemInfo.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SystemInfo
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.daemon.Timedate.service
+++ b/misc/dbus/services/com.deepin.daemon.Timedate.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Timedate
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.ControlCenter.service
+++ b/misc/dbus/services/com.deepin.dde.ControlCenter.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.ControlCenter
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.Dock.service
+++ b/misc/dbus/services/com.deepin.dde.Dock.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.Dock
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.Launcher.service
+++ b/misc/dbus/services/com.deepin.dde.Launcher.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.Launcher
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.Notification.service
+++ b/misc/dbus/services/com.deepin.dde.Notification.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.Notification
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.TrayManager.service
+++ b/misc/dbus/services/com.deepin.dde.TrayManager.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.TrayManager
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.daemon.Dock.service
+++ b/misc/dbus/services/com.deepin.dde.daemon.Dock.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Dock
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.daemon.Launcher.service
+++ b/misc/dbus/services/com.deepin.dde.daemon.Launcher.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Launcher
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.lockFront.service
+++ b/misc/dbus/services/com.deepin.dde.lockFront.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.lockFront
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.osd.service
+++ b/misc/dbus/services/com.deepin.dde.osd.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.osd
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/com.deepin.dde.shutdownFront.service
+++ b/misc/dbus/services/com.deepin.dde.shutdownFront.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.dde.shutdownFront
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.api.XEventMonitor1.service
+++ b/misc/dbus/services/org.deepin.api.XEventMonitor1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.api.XEventMonitor1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.Appearance1.service
+++ b/misc/dbus/services/org.deepin.daemon.Appearance1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.Appearance1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.Audio1.service
+++ b/misc/dbus/services/org.deepin.daemon.Audio1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.Audio1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.Bluetooth1.service
+++ b/misc/dbus/services/org.deepin.daemon.Bluetooth1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.Bluetooth1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.LangSelector1.service
+++ b/misc/dbus/services/org.deepin.daemon.LangSelector1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.LangSelector1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.Power1.service
+++ b/misc/dbus/services/org.deepin.daemon.Power1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.Power1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.SoundEffect1.service
+++ b/misc/dbus/services/org.deepin.daemon.SoundEffect1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.SoundEffect1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.SystemInfo1.service
+++ b/misc/dbus/services/org.deepin.daemon.SystemInfo1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.SystemInfo1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.deepin.daemon.Timedate1.service
+++ b/misc/dbus/services/org.deepin.daemon.Timedate1.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.daemon.Timedate1
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/dbus/services/org.desktopspec.permission.service
+++ b/misc/dbus/services/org.desktopspec.permission.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.desktopspec.permission
 Exec=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+SystemdService=dde-api-dbus-proxy-v1.service

--- a/misc/systemd/user/dde-api-dbus-proxy-v1.service
+++ b/misc/systemd/user/dde-api-dbus-proxy-v1.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=dde-api-proxy-session-v1 service for session
+
+Requires=dbus.socket
+After=dbus.socket
+
+Requisite=dde-session-pre.target
+PartOf=dde-session-pre.target
+Before=dde-session-pre.target
+
+Before=dde-display.service
+
+[Service]
+Type=simple
+ExecStart=/usr/lib/dde-api-proxy/dbus-proxy/dde-api-dbus-proxy-session-v1 --all
+Slice=session.slice

--- a/src/dbus-proxy/v1/session/main.cpp
+++ b/src/dbus-proxy/v1/session/main.cpp
@@ -56,10 +56,7 @@
 int main(int argc, char *argv[])
 {
     QCoreApplication a(argc, argv);
-    if (!DeepinRuntime::CheckStartddeSession()) {
-        qWarning() << "check startdde session error.";
-        return 0;
-    }
+
     QCommandLineParser parser;
     parser.setApplicationDescription("dde-api-proxy-session");
     parser.addHelpOption();


### PR DESCRIPTION
用户登录后，一些模块初始化时监听的是V0接口，此时dde-api-proxy可能还没有启动，导致初始化失败。现将api-proxy的启动提前到dde-display.service之前 Issue: https://github.com/linuxdeepin/developer-center/issues/9623