### PR TITLE
feat: 修复dde-api-proxy安全漏洞

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -13,3 +13,6 @@ install(FILES ${INSTALL_SYSTEMD_SYSTEM} DESTINATION lib/systemd/system/)
 
 file(GLOB_RECURSE INSTALL_SYSTEMD_USER ${CMAKE_CURRENT_SOURCE_DIR}/systemd/user/*.service)
 install(FILES ${INSTALL_SYSTEMD_USER} DESTINATION lib/systemd/user/)
+
+file(GLOB_RECURSE INSTALL_POLKIT_1 ${CMAKE_CURRENT_SOURCE_DIR}/polkit-1/actions/*.policy)
+install(FILES ${INSTALL_POLKIT_1} DESTINATION share/polkit-1/actions/)

--- a/misc/polkit-1/actions/org.deepin.dde.api.proxy.policy
+++ b/misc/polkit-1/actions/org.deepin.dde.api.proxy.policy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy 1.0//EN"
+    "http://www.freedesktop.org/standards/PolicyKit/1.0/policykit-policy.dtd">
+<policyconfig>
+    <action id="org.deepin.dde.api.proxy">
+        <message>Authentication is required to call the system proxy interface</message>
+        <message xml:lang="zh_CN">调用系统代理接口需要认证</message>
+        <defaults>
+            <allow_any>no</allow_any>
+            <allow_inactive>no</allow_inactive>
+            <allow_active>auth_admin_keep</allow_active>
+        </defaults>
+        <allow_users>
+            <user>root</user>
+        </allow_users>
+    </action>
+</policyconfig>

--- a/src/dbus-proxy/CMakeLists.txt
+++ b/src/dbus-proxy/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core DBus REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(DtkCore REQUIRED)
 find_package(DtkTools REQUIRED)
+find_package(PolkitQt5-1 REQUIRED)
 
 macro(qt5_add_dbus_proxy_interface_fix srcs xml class file neednamespace)
     if(${neednamespace})

--- a/src/dbus-proxy/v1/CMakeLists.txt
+++ b/src/dbus-proxy/v1/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(${PRO_NAME}
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::DBus
     ${DtkCore_LIBRARIES}
+    PolkitQt5-1::Core
  )
 target_include_directories(${PRO_NAME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Accounts1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Accounts1.hpp
@@ -15,6 +15,17 @@ public:
         QDBusConnection::BusType dbusType, QObject *parent = nullptr) 
         : DBusProxyBase(dbusName, dbusPath, dbusInterface, proxyDbusName, proxyDbusPath, proxyDbusInterface, dbusType, parent)
     {
+        QMap<QString, QString> auth;
+        auth["AllowGuestAccount"] = "org.deepin.dde.api.proxy";
+        auth["CreateGroup"] = "org.deepin.dde.api.proxy";
+        auth["CreateGuestAccount"] = "org.deepin.dde.api.proxy";
+        auth["CreateUser"] = "org.deepin.dde.api.proxy";
+        auth["DeleteGroup"] = "org.deepin.dde.api.proxy";
+        auth["DeleteUser"] = "org.deepin.dde.api.proxy";
+        auth["EnablePasswdChangedHandler"] = "org.deepin.dde.api.proxy";
+        auth["ModifyGroup"] = "org.deepin.dde.api.proxy";
+        auth["SetTerminalLocked"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Accounts1_User.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Accounts1_User.hpp
@@ -13,6 +13,42 @@ public:
         QDBusConnection::BusType dbusType, QObject *parent = nullptr) 
         : DBusProxyBase(dbusName, dbusPath, dbusInterface, proxyDbusName, proxyDbusPath, proxyDbusInterface, dbusType, parent)
     {
+        QMap<QString, QString> auth;
+        auth["AddGroup"] = "org.deepin.dde.api.proxy";
+        auth["DeleteGroup"] = "org.deepin.dde.api.proxy";
+        auth["DeleteIconFile"] = "org.deepin.dde.api.proxy";
+        auth["DeleteSecretKey"] = "org.deepin.dde.api.proxy";
+        auth["EnableNoPasswdLogin"] = "org.deepin.dde.api.proxy";
+        auth["EnableWechatAuth"] = "org.deepin.dde.api.proxy";
+        auth["SetAutomaticLogin"] = "org.deepin.dde.api.proxy";
+        auth["SetCurrentWorkspace"] = "org.deepin.dde.api.proxy";
+        auth["SetDesktopBackgrounds"] = "org.deepin.dde.api.proxy";
+        auth["SetFullName"] = "org.deepin.dde.api.proxy";
+        auth["SetGreeterBackground"] = "org.deepin.dde.api.proxy";
+        auth["SetGroups"] = "org.deepin.dde.api.proxy";
+        auth["SetHistoryLayout"] = "org.deepin.dde.api.proxy";
+        auth["SetHomeDir"] = "org.deepin.dde.api.proxy";
+        auth["SetIconFile"] = "org.deepin.dde.api.proxy";
+        auth["SetLayout"] = "org.deepin.dde.api.proxy";
+        auth["SetLocale"] = "org.deepin.dde.api.proxy";
+        auth["SetLocked"] = "org.deepin.dde.api.proxy";
+        auth["SetLongDateFormat"] = "org.deepin.dde.api.proxy";
+        auth["SetMaxPasswordAge"] = "org.deepin.dde.api.proxy";
+        auth["SetPassword"] = "org.deepin.dde.api.proxy";
+        auth["SetPasswordHint"] = "org.deepin.dde.api.proxy";
+        auth["SetQuickLogin"] = "org.deepin.dde.api.proxy";
+        auth["SetSecretKey"] = "org.deepin.dde.api.proxy";
+        auth["SetSecretQuestions"] = "org.deepin.dde.api.proxy";
+        auth["SetShell"] = "org.deepin.dde.api.proxy";
+        auth["SetShortDateFormat"] = "org.deepin.dde.api.proxy";
+        auth["SetShortTimeFormat"] = "org.deepin.dde.api.proxy";
+        auth["SetUse24HourFormat"] = "org.deepin.dde.api.proxy";
+        auth["SetWeekBegins"] = "org.deepin.dde.api.proxy";
+        auth["SetWeekdayFormat"] = "org.deepin.dde.api.proxy";
+        auth["UpdateWechatAuthState"] = "org.deepin.dde.api.proxy";
+        auth["VerifySecretQuestions"] = "org.deepin.dde.api.proxy";
+        auth["SetLongTimeFormat"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface * initConnect() {

--- a/src/dbus-proxy/v1/system/org_deepin_dde_AirplaneMode1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_AirplaneMode1.hpp
@@ -13,6 +13,11 @@ public:
         QDBusConnection::BusType dbusType, QObject *parent = nullptr) 
         : DBusProxyBase(dbusName, dbusPath, dbusInterface, proxyDbusName, proxyDbusPath, proxyDbusInterface, dbusType, parent)
     {
+        QMap<QString, QString> auth;
+        auth["Enable"] = "org.deepin.dde.api.proxy";
+        auth["EnableBluetooth"] = "org.deepin.dde.api.proxy";
+        auth["EnableWifi"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Display1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Display1.hpp
@@ -15,6 +15,10 @@ public:
     {
         InitFilterProperies(QStringList({}));
         InitFilterMethods(QStringList({"GetConfig"}));
+        QMap<QString, QString> auth;
+        auth["SetBacklightBrightness"] = "org.deepin.dde.api.proxy";
+        auth["SetConfig"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Gesture1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Gesture1.hpp
@@ -15,6 +15,11 @@ public:
     {
         InitFilterProperies(QStringList({}));
         InitFilterMethods(QStringList({}));
+        QMap<QString, QString> auth;
+        auth["SetEdgeMoveStopDuration"] = "org.deepin.dde.api.proxy";
+        auth["SetInputIgnore"] = "org.deepin.dde.api.proxy";
+        auth["SetShortPressDuration"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Grub2.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Grub2.hpp
@@ -15,6 +15,9 @@ public:
     {
         InitFilterProperies(QStringList({}));
         InitFilterMethods(QStringList({"SetTimeout"}));
+        QMap<QString, QString> auth;
+        auth["SetTimeout"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Grub2_Theme.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Grub2_Theme.hpp
@@ -15,6 +15,9 @@ public:
     {
         // InitFilterProperies(QStringList({}));
         // InitFilterMethods(QStringList({"SetBackgroundSourceFile"}));
+        QMap<QString, QString> auth;
+        auth["SetBackgroundSourceFile"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Network1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Network1.hpp
@@ -13,6 +13,10 @@ public:
         QDBusConnection::BusType dbusType, QObject *parent = nullptr) 
         : DBusProxyBase(dbusName, dbusPath, dbusInterface, proxyDbusName, proxyDbusPath, proxyDbusInterface, dbusType, parent)
     {
+        QMap<QString, QString> auth;
+        auth["EnableDevice"] = "org.deepin.dde.api.proxy";
+        auth["ToggleWirelessEnabled"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_PasswdConf1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_PasswdConf1.hpp
@@ -15,6 +15,16 @@ public:
     {
         InitFilterProperies(QStringList({}));
         InitFilterMethods(QStringList({"GetEnabled", "GetLengthLimit", "GetValidateRequired", "WriteConfig"}));
+        QMap<QString, QString> auth;
+        auth["Backup"] = "org.deepin.dde.api.proxy";
+        auth["Reset"] = "org.deepin.dde.api.proxy";
+        auth["SetEnabled"] = "org.deepin.dde.api.proxy";
+        auth["SetFirstLetterUpper"] = "org.deepin.dde.api.proxy";
+        auth["SetLengthLimit"] = "org.deepin.dde.api.proxy";
+        auth["SetValidatePolicy"] = "org.deepin.dde.api.proxy";
+        auth["SetValidateRequired"] = "org.deepin.dde.api.proxy";
+        auth["WriteConfig"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()

--- a/src/dbus-proxy/v1/system/org_deepin_dde_Timedate1.hpp
+++ b/src/dbus-proxy/v1/system/org_deepin_dde_Timedate1.hpp
@@ -15,6 +15,13 @@ public:
     {
         InitFilterProperies(QStringList({"NTPServer"}));
         InitFilterMethods(QStringList({"SetNTPServer"}));
+        QMap<QString, QString> auth;
+        auth["SetLocalRTC"] = "org.deepin.dde.api.proxy";
+        auth["SetNTP"] = "org.deepin.dde.api.proxy";
+        auth["SetNTPServer"] = "org.deepin.dde.api.proxy";
+        auth["SetTime"] = "org.deepin.dde.api.proxy";
+        auth["SetTimezone"] = "org.deepin.dde.api.proxy";
+        InitCheckAuthorization(auth);
         ServiceStart();
     }
     virtual DDBusExtendedAbstractInterface *initConnect()


### PR DESCRIPTION
dde-api-proxy系统级的dbus接口，使用普通用户也可以使用，有安全问题，因此添加了polkit鉴权。

Log: 修复dde-api-proxy安全漏洞
pms: task-371895