### PR TITLE
chore: bump version to 1.0.21

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-api-proxy (1.0.21) unstable; urgency=medium
+
+  * chore: remove unnecessary dependencies
+  * chore: license check
+  * refact: switch to qt6 for debian
+  * feat: adapt to qt6
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 27 Mar 2025 11:43:12 +0800
+
 dde-api-proxy (1.0.20) unstable; urgency=medium
 
   * fix: 修复dde-api-proxy安全漏洞


### PR DESCRIPTION
update changelog to 1.0.21

## Summary by Sourcery

Chores:
- Update project version in the Debian changelog file